### PR TITLE
Avl block counter

### DIFF
--- a/FStats/AVL.cpp
+++ b/FStats/AVL.cpp
@@ -86,7 +86,7 @@ size_t AVL::add(uint64_t block)
 
 		// Remember where we used to be
 		candidate = previous;
-		previous = block < previous->Block ? previous->Left : previous->Right;
+		previous = goingLeft ? previous->Left : previous->Right;
 	}
 
 	// We didn't find the node already, so we have to insert a new one
@@ -109,15 +109,15 @@ size_t AVL::add(uint64_t block)
 		delta = 1;
 
 		previous = lastRotationCandidate->Left;
-		nextAfterRotationCandidate = previous;
 	}
 	else
 	{
 		delta = -1;
 
 		previous = lastRotationCandidate->Right;
-		nextAfterRotationCandidate = previous;
 	}
+	nextAfterRotationCandidate = previous;
+
 
 	// Update balance factors, moving pointers along the way
 	while (previous != toInsert)

--- a/FStats/AVL.h
+++ b/FStats/AVL.h
@@ -32,26 +32,29 @@
 
 // A node in an AVL Tree. Basically, a Binary Tree Node
 // with an additional field for keeping track of the "balance factor"
-struct AVLTreeNode
+class AVLTreeNode
 {
+public:
 	const uint64_t Block;
-	size_t count = 1;
+	size_t count;
 
 	// The Left Child Node
-	AVLTreeNode* Left = nullptr;
+	AVLTreeNode* Left;
 	// The Right Child Node
-	AVLTreeNode* Right = nullptr;
+	AVLTreeNode* Right;
 
-	explicit AVLTreeNode(uint64_t block) : Block(block) {}
+	explicit AVLTreeNode(uint64_t block) : Block(block), Left(nullptr), Right(nullptr), count(1), BalanceFactor(0) {}
 
 	// The balance factor of the node
 	// This is the height of the left sub-tree minus the height of the right sub-tree
-	int8_t BalanceFactor = 0;
+	int8_t BalanceFactor;
 
 	virtual ~AVLTreeNode()
 	{
 		if (Left != nullptr) delete Left;
 		if (Right != nullptr) delete Right;
+
+		Left = Right = nullptr;
 	}
 
 };
@@ -97,4 +100,3 @@ private:
 	// Performs a rotation to handle the Right-Left case at the specified rotation candidate
 	static inline void rotateRightLeft(AVLTreeNode* lastRotationCandidate, AVLTreeNode*& nextAfterRotationCandidate);
 };
-

--- a/FStats/FStats.vcxproj
+++ b/FStats/FStats.vcxproj
@@ -129,8 +129,6 @@
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
     </ClCompile>

--- a/FStats/FStats.vcxproj
+++ b/FStats/FStats.vcxproj
@@ -131,6 +131,7 @@
       <Optimization>MaxSpeed</Optimization>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
So apparently `c++` doesn't like allocating tons of bytes on the stack. This commit simply uses AVL trees to keep track of stats instead.
